### PR TITLE
Replaced display CSS property by visibility

### DIFF
--- a/RQG/Views/Questions/Random.cshtml
+++ b/RQG/Views/Questions/Random.cshtml
@@ -8,11 +8,13 @@
     <script type="text/javascript">
 
         function toggle(id) {
-            var e = document.getElementById(id);
-            if (e.style.display == 'none')
-                e.style.display = 'block';
-            else
-                e.style.display = 'none';
+            var answer = document.getElementById(id);
+
+            if (answer.style.visibility == 'hidden') {
+                answer.style.visibility = 'visible';
+            } else {
+                answer.style.visibility = 'hidden';
+            }
         }
 
     </script>
@@ -32,7 +34,7 @@
 <p>@Html.ValueForModel(Model.Description) <a href="#" onclick="toggle('answer');">Reveal answer</a></p>
 
 
-<div style="display:none" id="answer">
+<div style="visibility:hidden" id="answer">
     <b>Answer: </b>@Html.ValueForModel(Model.Answer)
 </div>
 


### PR DESCRIPTION
Hi! 👋

This PR solves the problem addressed in https://github.com/BenjaminEllisWard/RQG/issues/2, I changed the CSS display property by visibility, that way its place in the DOM is respected even when is not shown. Also, I renamed the variable that holds the div element, just to be more explicit.

Note that this could be done in one line using the ternary operator like this: `answer.style.visibility = (answer.style.visibility == 'hidden') ? 'visible' : 'hidden'`, but I don't think is really neccessary.